### PR TITLE
correct linting and logical errors in certificate script

### DIFF
--- a/assets/javascript/certificate.js
+++ b/assets/javascript/certificate.js
@@ -1,6 +1,5 @@
 let printed
 window.addEventListener('load', (event) => {
-  const header = document.querySelector('h1')
   printed = false
 
   const backUrl = document.referrer
@@ -13,7 +12,7 @@ window.addEventListener('load', (event) => {
   }
 
   const backLink = document.querySelector('a.govuk-back-link')
-  backLink.addEventListener('click', updateHref)
+  backLink.addEventListener('click', () => updateHref(backUrl))
 })
 
 function resetBrowserHistory (window, url) {
@@ -21,7 +20,7 @@ function resetBrowserHistory (window, url) {
   window.history.pushState(null, document.title, url)
 }
 
-function updateHref () {
+function updateHref (backUrl) {
   if (printed === true) {
     this.setAttribute('href', backUrl)
   }


### PR DESCRIPTION
Running `npm run lint` came up with these errors re either unused variables (`header`) or references to variable not in scope (`backUrl`).