### PR TITLE
use better_errors gem for better DX for errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ ruby "2.7.3"
 source "https://rubygems.org" do
   group :development do
     gem "sinatra-contrib"
+    gem "better_errors"
+    gem "binding_of_caller"
   end
 
   group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,12 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (1.0.0)
+      debug_inspector (>= 0.0.1)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -25,13 +31,16 @@ GEM
       capybara
       selenium-webdriver
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
+    debug_inspector (1.1.0)
     diff-lcs (1.4.4)
     epb-auth-tools (1.0.8)
       jwt (~> 2.2)
       oauth2 (~> 1.4)
+    erubi (1.10.0)
     erubis (2.7.0)
     faraday (1.4.2)
       faraday-em_http (~> 1.0)
@@ -175,6 +184,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors!
+  binding_of_caller!
   capybara (~> 3.35.3)!
   capybara-selenium (~> 0.0.6)!
   epb-auth-tools (~> 1.0.8)!

--- a/lib/frontend_service.rb
+++ b/lib/frontend_service.rb
@@ -9,6 +9,11 @@ require_relative "helpers"
 require_relative "../lib/helper/toggles"
 
 class FrontendService < Sinatra::Base
+  require "better_errors"
+  use BetterErrors::Middleware
+  BetterErrors.editor = :rubymine
+  BetterErrors.application_root = __dir__
+
   helpers Sinatra::FrontendService::Helpers
   attr_reader :toggles
 
@@ -328,6 +333,7 @@ class FrontendService < Sinatra::Base
 
   find_a_certificate_property_type =
     lambda do
+      Time.nonexistent
       query = params.map { |key, value| "#{key}=#{value}" }.join("&")
       @errors = {}
       @page_title =
@@ -372,6 +378,7 @@ class FrontendService < Sinatra::Base
     locals = {}
     erb_template = :find_certificate_by_postcode
     back_link "/find-a-certificate/type-of-property"
+    Time.nonexistent
 
     @page_title =
       "#{t('find_certificate_by_postcode.top_heading')} - #{


### PR DESCRIPTION
It would provide better developer experience to have an error page that didn't just give you a bunch of stack tracing from within Rack. `better_errors` is a very popular gem for this - let's include it!

NB. Currently it is included according to the instructions but seemingly not taking precedence yet over Rack's own error handling!