### PR TITLE
EPBR-9146: Update product text on assessments with green deals

### DIFF
--- a/lib/views/domestic_energy_performance_certificate__green_deal_plan.erb
+++ b/lib/views/domestic_energy_performance_certificate__green_deal_plan.erb
@@ -44,7 +44,11 @@
   <dl class="govuk-summary-list">
     <% green_deal_plan[:measures].each do |green_deal_product| %>
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key govuk-!-width-one-half"><%= green_deal_product[:product] %></dt>
+        <% if green_deal_product[:product] == "Not Applicable" && !green_deal_product[:measureType].nil? %>
+          <dt class="govuk-summary-list__key govuk-!-width-one-half"><%= green_deal_product[:measureType] %></dt>
+        <% else %>
+          <dt class="govuk-summary-list__key govuk-!-width-one-half"><%= green_deal_product[:product] %></dt>
+        <% end %>
         <dd class="govuk-summary-list__value govuk-!-width-one-half"><%= ((green_deal_product[:repaidDate] == nil) or green_deal_product[:repaidDate].empty?) ? "" : "#{t('domestic_epc.sections.green_deal.paid_off_header')} #{date(green_deal_product[:repaidDate])}" %></dd>
       </div>
     <% end %>

--- a/spec/acceptance/view_domestic_certificate_spec.rb
+++ b/spec/acceptance/view_domestic_certificate_spec.rb
@@ -1048,6 +1048,86 @@ describe "Acceptance::DomesticEnergyPerformanceCertificate", type: :feature do
         expect(response.body).to include("Paid off 29 March 2025")
       end
 
+      it "shows the measure type instead of the product when the product is Not Applicable" do
+        expect(response.body).to include("Double glazing")
+      end
+
+      context "when the product is Not Applicable" do
+        FetchAssessmentSummary::AssessmentStub.fetch_rdsap(
+          assessment_id: "1111-1111-1111-1111-7846",
+          green_deal_plan: [
+            {
+              greenDealPlanId: "ABC123456DEF",
+              startDate: "2020-01-30",
+              endDate: "2030-02-28",
+              providerDetails: {
+                name: "The Bank",
+              },
+              interest: {
+                rate: 12.3,
+                fixed: true,
+              },
+              chargeUplift: {
+                amount: 1.25,
+                date: "2025-03-29",
+              },
+              ccaRegulated: true,
+              structureChanged: false,
+              measuresRemoved: false,
+              measures: [
+                {
+                  sequence: 0,
+                  measureType: "Loft insulation",
+                  product: "WarmHome lagging stuff (TM)",
+                  repaidDate: "2025-03-29",
+                },
+                {
+                  sequence: 1,
+                  product: "Not Applicable",
+                },
+              ],
+              charges: [
+                {
+                  sequence: 0,
+                  startDate: "2020-03-29",
+                  endDate: "2030-03-29",
+                  dailyCharge: "0.33",
+                },
+                {
+                  sequence: 1,
+                  startDate: "2020-03-29",
+                  endDate: "2030-03-29",
+                  dailyCharge: "0.01",
+                },
+              ],
+              savings: [
+                {
+                  fuelCode: "39",
+                  fuelSaving: 23_253,
+                  standingChargeFraction: 0,
+                },
+                {
+                  fuelCode: "40",
+                  fuelSaving: -6331,
+                  standingChargeFraction: -0.9,
+                },
+                {
+                  fuelCode: "41",
+                  fuelSaving: -15_561,
+                  standingChargeFraction: 0,
+                },
+              ],
+              estimatedSavings: 1566,
+            },
+          ],
+        )
+        let(:response) { get "/energy-certificate/1111-1111-1111-1111-7846" }
+
+        it "shows Not Applicable when there is no measure type" do
+          expect(response.body).to include("Not Applicable")
+        end
+      end
+
       it "shows the plan number" do
         expect(response.body).to include("Plan number")
         expect(response.body).to include("ABC123456DEF")

--- a/spec/test_doubles/fetch_assessment_summary/assessment_stub.rb
+++ b/spec/test_doubles/fetch_assessment_summary/assessment_stub.rb
@@ -1700,7 +1700,7 @@ module FetchAssessmentSummary
             {
               sequence: 1,
               measureType: "Double glazing",
-              product: "Not applicable",
+              product: "Not Applicable",
             },
           ],
           charges:,

--- a/spec/unit/use_case/fetch_certificate_spec.rb
+++ b/spec/unit/use_case/fetch_certificate_spec.rb
@@ -87,7 +87,7 @@ describe UseCase::FetchCertificate do
                 },
                 {
                   measureType: "Double glazing",
-                  product: "Not applicable",
+                  product: "Not Applicable",
                   sequence: 1,
                 },
               ],


### PR DESCRIPTION
display the measure type when available and when the product type is 'Not Applicable' as a more useful description.