### PR TITLE
EPBR-9436: Add test and lint github workflow action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,17 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "bundler"
-    directory: "/" # Location of package manifests
+    directory: "/"
     schedule:
       interval: "daily"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -1,0 +1,31 @@
+name: Lint and test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: echo "127.0.0.1 getting-new-energy-certificate.local.gov.uk find-energy-certificate.local.gov.uk" | sudo tee -a /etc/hosts
+      - name: Prepare assets
+        run: bundle exec ruby ./build/compile_assets.rb
+      - name: Lint
+        run: make lint
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help:
 .PHONY: frontend-build
 frontend-build: ## Run the frontend build process to compile sass and move asset files to public
 	@echo "Building frontend assets..."
-	ruby ./build/compile_assets.rb
+	@bundle exec ruby ./build/compile_assets.rb
 
 frontend-build-watch:
 	@$(SHELL) ./scripts/frontend-build-watch.sh
@@ -29,6 +29,10 @@ assets-version:
 .PHONY: run
 run:
 	@bundle exec rackup -p 9292 ${ARGS}
+
+.PHONY: lint
+lint:
+	@bundle exec rubocop && npm run lint
 
 .PHONY: formatmak
 format:

--- a/assets/javascript/__tests__/cookie-consent_test.js
+++ b/assets/javascript/__tests__/cookie-consent_test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 /* eslint-env jest */
 
 import cookieConsent from '../cookie-consent'

--- a/assets/javascript/__tests__/service-performance_test.js
+++ b/assets/javascript/__tests__/service-performance_test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 /* eslint-env jest */
 import { initButtons, getUrlParameter } from '../service-performance.js'
 describe('when rendering service performance in Welsh', () => {

--- a/assets/javascript/__tests__/share-certificate_test.js
+++ b/assets/javascript/__tests__/share-certificate_test.js
@@ -1,6 +1,3 @@
-/**
- * @jest-environment jsdom
- */
 /* eslint-env jest */
 import { copyToClipboard } from '../share-certificate.js'
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  testEnvironment: "jsdom",
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    // CI installs gems to /vendor/bundle/, which may contain tests
+    '/vendor/',
+  ],
+};


### PR DESCRIPTION
Add a github workflow pipeline to test and lint.  Also updated dependabot to generate updates for github actions version chanages.

- Added a `make lint` task as we need a task that will fail if the lint fails (unlike format which never fails)
- Updated `make frontend-build` to use `bundle exec` or the test runner can't find the sass executable.
- Added a `jest.config.js` as we need to exclude files in `/vendor/` when running on github actions.